### PR TITLE
parser: maintainability

### DIFF
--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -1,5 +1,5 @@
 use crate::parser::Event;
-use crate::parser::MarkedEventReceiver;
+use crate::parser::EventReceiver;
 use crate::parser::Parser;
 use crate::scanner::Marker;
 use crate::scanner::ScanError;
@@ -81,7 +81,7 @@ pub struct YamlLoader {
     anchor_map: BTreeMap<usize, Yaml>,
 }
 
-impl MarkedEventReceiver for YamlLoader {
+impl EventReceiver for YamlLoader {
     fn on_event(&mut self, ev: Event, _: Marker) {
         // println!("EV {:?}", ev);
         match ev {
@@ -199,8 +199,8 @@ impl YamlLoader {
             key_stack: Vec::new(),
             anchor_map: BTreeMap::new(),
         };
-        let mut parser = Parser::new(source.chars());
-        parser.load(&mut loader, true)?;
+        let mut parser = Parser::new(source.chars(), &mut loader);
+        parser.load(true)?;
         Ok(loader.docs)
     }
 }

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -82,8 +82,9 @@ pub struct YamlLoader {
 }
 
 impl EventReceiver for YamlLoader {
-    fn on_event(&mut self, ev: Event, _: Marker) {
-        // println!("EV {:?}", ev);
+    fn on_event(&mut self, ev: Event, _marker: Marker) {
+        #[cfg(test)]
+        println!("EV {:?} @ {:?}", ev, _marker);
         match ev {
             Event::DocumentStart => {
                 // do nothing

--- a/tests/spec_test.rs
+++ b/tests/spec_test.rs
@@ -5,6 +5,7 @@ extern crate yaml_rust;
 use yaml_rust::parser::Event;
 use yaml_rust::parser::EventReceiver;
 use yaml_rust::parser::Parser;
+use yaml_rust::scanner::Marker;
 use yaml_rust::scanner::TScalarStyle;
 
 // These names match the names used in the C++ test suite.
@@ -27,7 +28,7 @@ struct YamlChecker {
 }
 
 impl EventReceiver for YamlChecker {
-    fn on_event(&mut self, ev: Event) {
+    fn on_event(&mut self, ev: Event, _mark: Marker) {
         let tev = match ev {
             Event::DocumentStart => TestEvent::OnDocumentStart,
             Event::DocumentEnd => TestEvent::OnDocumentEnd,
@@ -51,8 +52,8 @@ impl EventReceiver for YamlChecker {
 
 fn str_to_test_events(docs: &str) -> Vec<TestEvent> {
     let mut p = YamlChecker { evs: Vec::new() };
-    let mut parser = Parser::new(docs.chars());
-    parser.load(&mut p, true).unwrap();
+    let mut parser = Parser::new(docs.chars(), &mut p);
+    parser.load(true).unwrap();
     p.evs
 }
 


### PR DESCRIPTION
- Move the receiver as a field of the struct
- Remove dead methods, make stuff private, create emit method
- Stop differentiating between regular receiver and marked receiver, marks are useful.