### PR TITLE
feature: add support to scan, parse and emit comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+### Notes about this fork
+
+This fork results from a personal desire for `yaml-rust` to support parsing and emitting comments.
+The original parser implementation was heavily inspired by the C++ canonical parsers, and these
+did not come with comment support. [See the PR that added comment support.](https://github.com/alevinval/yaml-rust/pull/9)
+
+As part of undertaking this effort, some refactors for the purpose of maintaining of the library had to be done
+as well, but that was never the main goal. Also, my personal desire would be that the fork could eventually
+be merged back in [chyh1990/yaml-rust](chyh1990/yaml-rust), which at the moment of writing, is no longer maintained.
+
 # yaml-rust
 
 The missing YAML 1.2 implementation for Rust.

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -2,7 +2,10 @@ pub use self::error::EmitError;
 use self::funcs::escape_str;
 use self::funcs::need_quotes;
 use crate::yaml::Hash;
-use crate::yaml::{IntegerFormat, Meta, StringFormat, Yaml};
+use crate::yaml::IntegerFormat;
+use crate::yaml::Meta;
+use crate::yaml::StringFormat;
+use crate::yaml::Yaml;
 use std::fmt;
 
 mod error;
@@ -110,14 +113,14 @@ impl<'a> YamlEmitter<'a> {
             Meta::Integer(f, node) => {
                 let old = self.intformat;
                 self.intformat = *f;
-                let res = self.emit_node(&node);
+                let res = self.emit_node(node);
                 self.intformat = old;
                 res
             }
             Meta::String(f, node) => {
                 let old = self.strformat;
                 self.strformat = *f;
-                let res = self.emit_node(&node);
+                let res = self.emit_node(node);
                 self.strformat = old;
                 res
             }
@@ -175,34 +178,34 @@ impl<'a> YamlEmitter<'a> {
         let mut i = BUFSZ;
         let mut value = value as u64;
         loop {
-            i = i - 1;
+            i -= 1;
             match value % base {
                 x if x < 10 => s[i] = b'0' + (x as u8),
                 x => s[i] = b'A' + x as u8 - 10,
             };
-            value = value / base;
+            value /= base;
             if value == 0 {
                 break;
             }
         }
         while BUFSZ - i < width {
-            i = i - 1;
+            i -= 1;
             s[i] = b'0';
         }
         match self.intformat {
             IntegerFormat::Binary(_) => {
-                i = i - 2;
+                i -= 2;
                 s[i] = b'0';
                 s[i + 1] = b'b';
             }
             IntegerFormat::Hex(_) => {
-                i = i - 2;
+                i -= 2;
                 s[i] = b'0';
                 s[i + 1] = b'x';
             }
             IntegerFormat::Octal(_) => {
                 if s[i] != b'0' {
-                    i = i - 1;
+                    i -= 1;
                     s[i] = b'0';
                 }
             }

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -8,29 +8,6 @@ use std::fmt;
 mod error;
 mod funcs;
 
-macro_rules! debug_comment {
-  ($msg:expr) => {
-    comment_debug!($msg,);
-  };
-  ($msg:expr, $($opt:expr), *) => {
-    println!("[DEBUG-COMMENT]");
-    println!(" => {}", $msg);
-    $(
-      println!(" => {}: {:?}", stringify!($opt), $opt);
-    )*
-  };
-}
-
-macro_rules! debug_comment_disallowed {
-  ($msg:expr) => {
-    debug_comment_disallowed!($msg,);
-  };
-  ($msg:expr, $($opt:expr), *) => {
-    debug_comment!($msg, $($opt)*);
-    unreachable!("[DEBUG-COMMENT-DISALLOWED]");
-  };
-}
-
 pub struct YamlEmitter<'a> {
     writer: &'a mut dyn fmt::Write,
     best_indent: usize,
@@ -156,7 +133,6 @@ impl<'a> YamlEmitter<'a> {
             }
 
             if entry.is_comment() {
-                debug_comment!("emitting comment inside array (as entry)", entry);
                 self.emit_node(entry)?;
                 continue;
             }
@@ -194,7 +170,6 @@ impl<'a> YamlEmitter<'a> {
             }
 
             if key.is_comment() {
-                debug_comment!("emitting comment inside hash (as key)", key);
                 self.emit_node(key)?;
                 continue;
             }
@@ -263,7 +238,7 @@ impl<'a> YamlEmitter<'a> {
                 self.emit_hash(hash)
             }
             Yaml::Comment(_, _) => {
-                debug_comment_disallowed!("should never emit comment as value", value);
+                unreachable!("should never emit comment as a value: {:?}", value)
             }
             _ => {
                 write!(self.writer, " ")?;

--- a/src/emitter/error.rs
+++ b/src/emitter/error.rs
@@ -8,6 +8,7 @@ use std::fmt::Result;
 pub enum EmitError {
     FmtError(FmtError),
     BadHashmapKey,
+    IntFmtWidth,
 }
 
 impl Error for EmitError {
@@ -21,6 +22,7 @@ impl Display for EmitError {
         match *self {
             EmitError::FmtError(ref err) => Display::fmt(err, formatter),
             EmitError::BadHashmapKey => formatter.write_str("bad hashmap key"),
+            EmitError::IntFmtWidth => formatter.write_str("bad integer format width"),
         }
     }
 }

--- a/src/emitter/funcs.rs
+++ b/src/emitter/funcs.rs
@@ -1,14 +1,16 @@
 use std::fmt;
 
 // from serialize::json
-pub fn escape_str(wr: &mut dyn fmt::Write, v: &str) -> Result<(), fmt::Error> {
-    wr.write_str("\"")?;
+pub fn escape_str(wr: &mut dyn fmt::Write, v: &str, quoted: bool) -> Result<(), fmt::Error> {
+    if quoted {
+        wr.write_str("\"")?;
+    }
 
     let mut start = 0;
 
     for (i, byte) in v.bytes().enumerate() {
         let escaped = match byte {
-            b'"' => "\\\"",
+            b'"' if quoted => "\\\"",
             b'\\' => "\\\\",
             b'\x00' => "\\u0000",
             b'\x01' => "\\u0001",
@@ -58,8 +60,9 @@ pub fn escape_str(wr: &mut dyn fmt::Write, v: &str) -> Result<(), fmt::Error> {
     if start != v.len() {
         wr.write_str(&v[start..])?;
     }
-
-    wr.write_str("\"")?;
+    if quoted {
+        wr.write_str("\"")?;
+    }
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ mod tests {
         let docs = YamlLoader::load_from_str(s).unwrap();
         let doc = &docs[0];
 
-        assert_eq!(doc[0]["name"].as_str().unwrap(), "Ogre");
+        assert_eq!(doc[1]["name"].as_str().unwrap(), "Ogre");
 
         let mut writer = String::new();
         {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -34,7 +34,7 @@ impl<'re, T: Iterator<Item = char>, R: EventReceiver> Parser<'re, T, R> {
     pub fn new(src: T, recv: &'re mut R) -> Parser<T, R> {
         Parser {
             recv,
-            scanner: Scanner::new(src),
+            scanner: Scanner::new(src, false),
             states: Vec::new(),
             state: State::StreamStart,
             token: None,

--- a/src/parser/event.rs
+++ b/src/parser/event.rs
@@ -12,12 +12,14 @@ pub enum Event {
     DocumentStart,
     DocumentEnd,
     Alias(AnchorID),
-    /// Value, style, anchor_id, tag
+    /// value, style, anchor_id, tag
     Scalar(String, TScalarStyle, AnchorID, Option<TokenType>),
     SequenceStart(AnchorID),
     SequenceEnd,
     MappingStart(AnchorID),
     MappingEnd,
+    // comment, inline
+    Comment(String, bool),
 }
 
 pub fn empty_scalar() -> Event {

--- a/src/scanner/types.rs
+++ b/src/scanner/types.rs
@@ -40,7 +40,8 @@ pub enum TokenType {
     /// handle, suffix
     Tag(String, String),
     Scalar(TScalarStyle, String),
-    Comment(String),
+    // comment, inline
+    Comment(String, bool),
 }
 
 #[derive(Clone, PartialEq, Debug, Eq)]

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -53,6 +53,8 @@ pub enum Yaml {
     Alias(usize),
     /// Comment, Inline
     Comment(string::String, bool),
+    /// Meta operation (set emitter formatting options)
+    Meta(Meta),
     /// YAML null, e.g. `null` or `~`.
     Null,
     /// Accessing a nonexistent node via the Index trait returns `BadValue`.
@@ -63,6 +65,31 @@ pub enum Yaml {
 
 pub type Array = Vec<Yaml>;
 pub type Hash = LinkedHashMap<Yaml, Yaml>;
+
+#[derive(Clone, Copy, PartialEq, PartialOrd, Debug, Eq, Ord, Hash)]
+pub enum IntegerFormat {
+    /// Integer in binary zero padded to the given width.
+    Binary(u32),
+    /// Integer in decimal.
+    Decimal,
+    /// Integer in hexadecimal zero padded to the given width.
+    Hex(u32),
+    /// Integer in octal zero padded to the given width.
+    Octal(u32),
+}
+
+#[derive(Clone, Copy, PartialEq, PartialOrd, Debug, Eq, Ord, Hash)]
+pub enum StringFormat {
+    Standard,
+    Quoted,
+    Block,
+}
+
+#[derive(Clone, PartialEq, PartialOrd, Debug, Eq, Ord, Hash)]
+pub enum Meta {
+    Integer(IntegerFormat, Box<Yaml>),
+    String(StringFormat, Box<Yaml>),
+}
 
 // parse f64 as Core schema
 // See: https://github.com/chyh1990/yaml-rust/issues/51

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -200,7 +200,7 @@ impl YamlLoader {
             key_stack: Vec::new(),
             anchor_map: BTreeMap::new(),
         };
-        let mut parser = Parser::new(source.chars(), &mut loader);
+        let mut parser = Parser::new(source.chars(), &mut loader, true);
         parser.load(true)?;
         Ok(loader.docs)
     }

--- a/tests/fixtures/emitter/comments-001.expected.yaml
+++ b/tests/fixtures/emitter/comments-001.expected.yaml
@@ -1,14 +1,21 @@
 ---
 repos:
+  # Is this supported?
   - repo: "https://github.com/rapidsai/frigate/"
-    rev: v0.4.0
+    rev: v0.4.0 #  pre-commit autoupdate  - to keep the version up to date
+    # and an in between keys comment here
     hooks:
       - id: frigate
+        # Initial comment
         versions:
-          - 1
+          - 1 # An inline comment
+          # What?
+          # Another comment
+          # More comments...
           - 2
-          - 3
+          - 3 # The last comment
+          # And a confusing one too
   - repo: "https://github.com/gruntwork-io/pre-commit"
-    rev: v0.1.12
+    rev: v0.1.12 #  pre-commit autoupdate  - to keep the version up to date
     hooks:
       - id: "helmlint\""

--- a/tests/fixtures/emitter/comments-002.expected.yaml
+++ b/tests/fixtures/emitter/comments-002.expected.yaml
@@ -1,4 +1,7 @@
 ---
+# Default values for example.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
 replicaCount: 1
 image:
   repository: nginx
@@ -8,20 +11,35 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 serviceAccount:
+  # Specifies whether a service account should be created
   create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
   name: some name
 podSecurityContext: {}
+# fsGroup: 2000
 securityContext: {}
+# capabilities:
+#   drop:
+#   - ALL
+# readOnlyRootFilesystem: true
+# runAsNonRoot: true
+# runAsUser: 1000
 service:
   type: ClusterIP
   port: 80
 ingress:
   enabled: false
   annotations: {}
+  # kubernetes.io/ingress.class: nginx
+  # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
       paths: []
       tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
 resources: {}
 nodeSelector: {}
 tolerations: []

--- a/tests/fixtures/emitter/comments-array-deep.expected.yaml
+++ b/tests/fixtures/emitter/comments-array-deep.expected.yaml
@@ -1,14 +1,40 @@
----
-- level1:
-    - first:
-        - 1
-        - 2
-    - level2:
-        - second:
-            - 1
-            - 2
+--- # inlined document begin comment
+# initial comment 1
+# initial comment 2
+# initial comment 3
+# before level 1
+- level1: # inline level 1
+    # before first
+    - first: # inline first
+        # before 1
+        - 1 # inline 1
+        # before 2
+        - 2 # inline 2
+        # after 2
+    # after first
+    # before level 2
+    - level2: # inline level 2
+        # before second
+        - second: # inline second
+            # before 1
+            - 1 # inline 1
+            # before 2
+            - 2 # inline 2
+            # after 2
+        # after second
+        # before level 3
         - level3:
-            - third:
-                - 1
-                - 2
-- last: 1
+            # before third
+            - third: # inline third
+                # before 1
+                - 1 # inline 1
+                # before 2
+                - 2 # inline 2
+                # after 2
+            # after third
+        # after level 3
+    # after level 2
+# after level 1
+# before last
+- last: 1 # inline last
+# after last

--- a/tests/fixtures/emitter/comments-array.expected.yaml
+++ b/tests/fixtures/emitter/comments-array.expected.yaml
@@ -1,5 +1,16 @@
----
-- entry: value
-- array:
-    - first: 1
-    - second: 2
+--- # Inlined document begin comment
+# Initial comment 1
+# Initial comment 2
+# Initial comment 3
+# Before entry
+- entry: value # Inlined entry
+# After entry
+# Before array
+- array: # Inlined array
+    # Before first
+    - first: 1 # Inlined first
+    # After first
+    # Before second
+    - second: 2 # Inlined second
+    # After second
+# After array

--- a/tests/fixtures/emitter/comments-hash-deep.expected.yaml
+++ b/tests/fixtures/emitter/comments-hash-deep.expected.yaml
@@ -1,12 +1,37 @@
----
-key: value
-deep_map:
-  level1:
-    one: value
-    level2:
-      two: two
-      level3:
-        three: three
-array:
-  - first: 1
-  - second: 2
+--- # inlined document begin comment
+# initial comment 1
+# initial comment 2
+# initial comment 3
+# before key
+key: value # inlined key
+# after key
+# before deep_map
+deep_map: # inline deep_map
+  # before level 1
+  level1: # inline level 1
+    # before one
+    one: value # inline one
+    # after one
+    # before level 2
+    level2: # inline level 2
+      # before two
+      two: two # inline two
+      # after two
+      # before level 3
+      level3: # inline level 3
+        # before three
+        three: three # inline three
+        # after three
+      # after level 3
+    # after level 2
+  # after level 1
+# after deep_map
+# before array
+array: # inlined array
+  # before first
+  - first: 1 # inlined first
+  # after first
+  # before second
+  - second: 2 # inlined second
+  # after second
+# after array

--- a/tests/fixtures/emitter/comments-hash.expected.yaml
+++ b/tests/fixtures/emitter/comments-hash.expected.yaml
@@ -1,5 +1,16 @@
----
-key: value
-array:
-  - first: 1
-  - second: 2
+--- # Inlined document begin comment
+# Initial comment 1
+# Initial comment 2
+# Initial comment 3
+# Before key
+key: value # Inlined key
+# After key
+# Before array
+array: # Inlined array
+  # Before first
+  - first: 1 # Inlined first
+  # After first
+  # Before second
+  - second: 2 # Inlined second
+  # After second
+# After array

--- a/tests/fixtures/emitter/simple.expected.yaml
+++ b/tests/fixtures/emitter/simple.expected.yaml
@@ -1,9 +1,9 @@
----
+--- # comment
 a0 bb: val
 a1:
   b1: 4
   b2: d
-a2: 4
+a2: 4 # i'm comment
 a3:
   - 1
   - 2

--- a/tests/spec_test.rs
+++ b/tests/spec_test.rs
@@ -52,7 +52,7 @@ impl EventReceiver for YamlChecker {
 
 fn str_to_test_events(docs: &str) -> Vec<TestEvent> {
     let mut p = YamlChecker { evs: Vec::new() };
-    let mut parser = Parser::new(docs.chars(), &mut p);
+    let mut parser = Parser::new(docs.chars(), &mut p, true);
     parser.load(true).unwrap();
     p.evs
 }


### PR DESCRIPTION
- Updates scanner to detect and emit comments, provides the content of the comment and whether it is inline or not.
- Updates parser to emit comments when fetching new tokens, this way the state machine is not affected in any way.
- Updates the loader to properly construct the node tree.
- Updates the emitter to generate YAML with comments.