### PR TITLE
Add emitter support for integer bases and block strings

### DIFF
--- a/src/emitter/error.rs
+++ b/src/emitter/error.rs
@@ -8,6 +8,7 @@ use std::fmt::Result;
 pub enum EmitError {
     FmtError(FmtError),
     BadHashmapKey,
+    IntFmtWidth,
 }
 
 impl Error for EmitError {
@@ -21,6 +22,7 @@ impl Display for EmitError {
         match *self {
             EmitError::FmtError(ref err) => Display::fmt(err, formatter),
             EmitError::BadHashmapKey => formatter.write_str("bad hashmap key"),
+            EmitError::IntFmtWidth => formatter.write_str("bad integer format width"),
         }
     }
 }

--- a/src/emitter/funcs.rs
+++ b/src/emitter/funcs.rs
@@ -1,14 +1,16 @@
 use std::fmt;
 
 // from serialize::json
-pub fn escape_str(wr: &mut dyn fmt::Write, v: &str) -> Result<(), fmt::Error> {
-    wr.write_str("\"")?;
+pub fn escape_str(wr: &mut dyn fmt::Write, v: &str, quoted: bool) -> Result<(), fmt::Error> {
+    if quoted {
+        wr.write_str("\"")?;
+    }
 
     let mut start = 0;
 
     for (i, byte) in v.bytes().enumerate() {
         let escaped = match byte {
-            b'"' => "\\\"",
+            b'"' if quoted => "\\\"",
             b'\\' => "\\\\",
             b'\x00' => "\\u0000",
             b'\x01' => "\\u0001",
@@ -58,8 +60,9 @@ pub fn escape_str(wr: &mut dyn fmt::Write, v: &str) -> Result<(), fmt::Error> {
     if start != v.len() {
         wr.write_str(&v[start..])?;
     }
-
-    wr.write_str("\"")?;
+    if quoted {
+        wr.write_str("\"")?;
+    }
     Ok(())
 }
 

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -53,6 +53,8 @@ pub enum Yaml {
     Alias(usize),
     /// Comment, Inline
     Comment(string::String, bool),
+    /// Meta operation (set emitter formatting options)
+    Meta(Meta),
     /// YAML null, e.g. `null` or `~`.
     Null,
     /// Accessing a nonexistent node via the Index trait returns `BadValue`.
@@ -63,6 +65,31 @@ pub enum Yaml {
 
 pub type Array = Vec<Yaml>;
 pub type Hash = LinkedHashMap<Yaml, Yaml>;
+
+#[derive(Clone, Copy, PartialEq, PartialOrd, Debug, Eq, Ord, Hash)]
+pub enum IntegerFormat {
+    /// Integer in binary zero padded to the given width.
+    Binary(u32),
+    /// Integer in decimal.
+    Decimal,
+    /// Integer in hexadecimal zero padded to the given width.
+    Hex(u32),
+    /// Integer in octal zero padded to the given width.
+    Octal(u32),
+}
+
+#[derive(Clone, Copy, PartialEq, PartialOrd, Debug, Eq, Ord, Hash)]
+pub enum StringFormat {
+    Standard,
+    Quoted,
+    Block,
+}
+
+#[derive(Clone, PartialEq, PartialOrd, Debug, Eq, Ord, Hash)]
+pub enum Meta {
+    Integer(IntegerFormat, Box<Yaml>),
+    String(StringFormat, Box<Yaml>),
+}
 
 // parse f64 as Core schema
 // See: https://github.com/chyh1990/yaml-rust/issues/51


### PR DESCRIPTION
1. Add a `Meta` node type for emitter options which are not
   round-trip-able.
2. Support emitting nodes with different integer bases.
3. Support emitting nodes with different string formatting options.

Signed-off-by: Chris Frantz <frantzcj@gmail.com>