### PR TITLE
Support 128-bit integers & DocFragments

### DIFF
--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -68,14 +68,14 @@ pub type Hash = LinkedHashMap<Yaml, Yaml>;
 
 #[derive(Clone, Copy, PartialEq, PartialOrd, Debug, Eq, Ord, Hash)]
 pub enum IntegerFormat {
-    /// Integer in binary zero padded to the given width.
-    Binary(u32),
+    /// Emit Integer (sized `bits`) in binary zero padded to the given `width`.
+    Binary(u32, u32),
     /// Integer in decimal.
     Decimal,
-    /// Integer in hexadecimal zero padded to the given width.
-    Hex(u32),
-    /// Integer in octal zero padded to the given width.
-    Octal(u32),
+    /// Emit Integer (sized `bits`) in hex zero padded to the given `width`.
+    Hex(u32, u32),
+    /// Emit Integer (sized `bits`) in octal zero padded to the given `width`.
+    Octal(u32, u32),
 }
 
 #[derive(Clone, Copy, PartialEq, PartialOrd, Debug, Eq, Ord, Hash)]
@@ -89,6 +89,7 @@ pub enum StringFormat {
 pub enum Meta {
     Integer(IntegerFormat, Box<Yaml>),
     String(StringFormat, Box<Yaml>),
+    Int128(i128),
 }
 
 // parse f64 as Core schema

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -87,6 +87,7 @@ pub enum StringFormat {
 
 #[derive(Clone, PartialEq, PartialOrd, Debug, Eq, Ord, Hash)]
 pub enum Meta {
+    Fragment(Vec<Yaml>),
     Integer(IntegerFormat, Box<Yaml>),
     String(StringFormat, Box<Yaml>),
     Int128(i128),
@@ -346,6 +347,13 @@ impl Yaml {
             inline
         } else {
             false
+        }
+    }
+
+    pub fn get_comment_fragment(&self) -> Option<&[Yaml]> {
+        match self {
+            Yaml::Meta(Meta::Fragment(f)) if f.len() == 2 && f[0].is_comment() => Some(f),
+            _ => None,
         }
     }
 


### PR DESCRIPTION
1. Add support for 128-bit integers.
2. Support Document Fragments in the Meta enum.
   DocFragments are needed so that serde-yaml can always emit a `Yaml` object rather than something like a Vec<Yaml>.

(2) represents a slight mismatch with the way comment support is handled in alevinval's branch (please review and advise.).  IMHO, requiring serde-yaml to return `Vec<Yaml>` from it's functions incurs allocation overhead for every field serialized.  `Meta::Fragment`s contain a `Vec<Yaml>`, so there is allocation for all fields with comments.  But, for all fields without comments, there is no additional allocation.